### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,15 @@
 			}
 		}
 
+		// wrap the superclass constructor if the subclass doesn't have one;
+		// without the wrap, we would later change the "constructor" property
+		// for both the superclass AND the new class and thereby screw up the
+		// inheritance chain
+		if(_super.init && !props.init) {
+			props.init = function() {
+				this._super.apply(this, arguments);
+			};
+		}
 
 		// Instantiate a base class (but only create the instance,
 		// don't run the init constructor)


### PR DESCRIPTION
Bugfix: inheritance chain breaks when parent class has an init method and extension doesn't provide one; constructor property of the original init method is then overwritten and breaks the superclass. The update fixes this problem by wrapping the original init method when the subclass hasn't defined one; the constructor property of this new function can than be overwritten without affecting the original function.
